### PR TITLE
Added support for self hosted HipChat instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This uses the new HipChat v2 API. [HipChat API Info](https://developer.atlassian
 
 ####Add a new media type to Zabbix
 
-![Alt text](/imgs/zbx-media type.png?raw=true "Media Type")
+![Alt text](/imgs/zbx-media%20type.png?raw=true "Media Type")
 
 Point the script to the bash file if your having trouble getting the python script to run directly.
 

--- a/hipcard.py
+++ b/hipcard.py
@@ -210,7 +210,10 @@ class ZabbixAlert(object):
                   self._formatmessage(), 'card': self._card(), 'message_format':
                   'html'}
         params = {'auth_token': self.token}
-        resp = requests.post('https://{0}.hipchat.com/v2/room/{1}/notification'.
+        pattern = re.compile("^http(s|)://")
+        if not pattern.match(self.hipname):
+            self.hipname = "https://{0}.hipchat.com".format(self.hipname)
+        resp = requests.post('{0}/v2/room/{1}/notification'.
                              format(self.hipname, self.roomid), data=json.dumps
                              (payload), headers=self.HEADERS, params=params)
         return resp


### PR DESCRIPTION
- Added support for self hosted HipChat instances (name has to start with http:// or https://)
- Fixed broken image in readme

This fixes issue #3 